### PR TITLE
Make it usable for the kafka connect's confluent platform 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -53,7 +73,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>0.9.0.0</version>
+            <version>0.10.0.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -70,7 +90,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>2.0.0</version>
+            <version>2.3.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/apache/kafka/connect/elasticsearchschema/ElasticsearchSinkConnector.java
+++ b/src/main/java/org/apache/kafka/connect/elasticsearchschema/ElasticsearchSinkConnector.java
@@ -1,5 +1,6 @@
 package org.apache.kafka.connect.elasticsearchschema;
 
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -128,4 +129,10 @@ public class ElasticsearchSinkConnector extends SinkConnector {
     public void stop() {
         // Nothing to do
     }
+
+    @Override
+    public ConfigDef config() {
+        return null;
+    }
+
 }


### PR DESCRIPTION
Add maven plugin to generate uber jar so you can use it with confluent platform
upgrade kafka to 0.10.0.0
upgrade to elastic search version to get rid of the lucene error while using the uber jar
add the override method on the ElasticsearchSinkConnector
